### PR TITLE
ENH/DOC: add missing description of scipy.special.expit

### DIFF
--- a/reference/special.html
+++ b/reference/special.html
@@ -1,7 +1,7 @@
 
 <!DOCTYPE html>
 
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="generator" content="Docutils 0.17.1: http://docutils.sourceforge.net/" />
@@ -1230,7 +1230,7 @@ functions are provided.</p>
 <td><p>Logit ufunc for ndarrays.</p></td>
 </tr>
 <tr class="row-even"><td><p><a class="reference internal" href="generated/scipy.special.expit.html#scipy.special.expit" title="scipy.special.expit"><code class="xref py py-obj docutils literal notranslate"><span class="pre">expit</span></code></a>(x)</p></td>
-<td><p>Expit (a.k.a.</p></td>
+<td><p>Expit (a.k.a. logistic sigmoid) ufunc for ndarrays.</p></td>
 </tr>
 <tr class="row-odd"><td><p><a class="reference internal" href="generated/scipy.special.boxcox.html#scipy.special.boxcox" title="scipy.special.boxcox"><code class="xref py py-obj docutils literal notranslate"><span class="pre">boxcox</span></code></a>(x, lmbda)</p></td>
 <td><p>Compute the Box-Cox transformation.</p></td>


### PR DESCRIPTION
This adds part of a description that was missing.